### PR TITLE
Remove beget/sprutio-nginx, add official nginx with custom config and certs

### DIFF
--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -1,4 +1,0 @@
-FROM nginx:1.9
-MAINTAINER "Maksim Losev <mlosev@beget.ru>"
-
-COPY nginx.conf /etc/nginx/nginx.conf

--- a/app/init-ssl.sh
+++ b/app/init-ssl.sh
@@ -9,3 +9,5 @@ fi
 
 openssl req -nodes -newkey rsa:4096 -keyout sprutio.key -out sprutio.csr -subj "/C=RU/O=Beget/CN=sprut.io"
 openssl x509 -req -days 365 -in sprutio.csr -signkey sprutio.key -out sprutio.crt
+
+chmod 400 sprutio.key

--- a/app/init-ssl.sh
+++ b/app/init-ssl.sh
@@ -10,5 +10,5 @@ fi
 openssl req -nodes -newkey rsa:4096 -keyout sprutio.key -out sprutio.csr -subj "/C=RU/O=Beget/CN=sprut.io"
 openssl x509 -req -days 365 -in sprutio.csr -signkey sprutio.key -out sprutio.crt
 
-chmod 600 ../certs
+chmod 700 ../certs
 chmod 400 sprutio.key

--- a/app/init-ssl.sh
+++ b/app/init-ssl.sh
@@ -10,4 +10,5 @@ fi
 openssl req -nodes -newkey rsa:4096 -keyout sprutio.key -out sprutio.csr -subj "/C=RU/O=Beget/CN=sprut.io"
 openssl x509 -req -days 365 -in sprutio.csr -signkey sprutio.key -out sprutio.crt
 
+chmod 600 ../certs
 chmod 400 sprutio.key

--- a/app/init-ssl.sh
+++ b/app/init-ssl.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/with-contenv bash
 set -e
 
-cd /app/ssl
+cd /app/nginx/certs
 
 if [ -s sprutio.key -a -s sprutio.crt ]; then
     exit 0

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -13,7 +13,7 @@ nginx:
   volumes_from:
     - cron
   volumes:
-    - "./nginx.conf:/etc/nginx/nginx.conf:ro"
+    - "./nginx:/etc/nginx:ro"
     - "./app/public:/app/public:ro"
 
 cron:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ rpc:
     - "./rpc.env"
 
 nginx:
-  image: nginx:1.9
+  image: nginx:mainline-alpine
   links:
     - app:fm-app
   volumes_from:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ app:
   volumes_from:
     - frontend
   volumes:
-    - "./ssl:/app/ssl:rw"
+    - "./nginx/certs:/app/nginx/certs:rw"
     - "./logs:/var/log/fm:rw"
   env_file:
     - "./app.env"
@@ -25,14 +25,14 @@ rpc:
     - "./rpc.env"
 
 nginx:
-  image: beget/sprutio-nginx
+  image: nginx:1.9
   links:
     - app:fm-app
   volumes_from:
     - cron
     - frontend
   volumes:
-    - "./ssl:/app/ssl:ro"
+    - "./nginx:/etc/nginx:ro"
     - "./logs:/var/log/nginx:rw"
   ports:
     - "127.0.0.1:9080:80"

--- a/nginx/mime.types
+++ b/nginx/mime.types
@@ -1,0 +1,89 @@
+
+types {
+    text/html                             html htm shtml;
+    text/css                              css;
+    text/xml                              xml;
+    image/gif                             gif;
+    image/jpeg                            jpeg jpg;
+    application/javascript                js;
+    application/atom+xml                  atom;
+    application/rss+xml                   rss;
+
+    text/mathml                           mml;
+    text/plain                            txt;
+    text/vnd.sun.j2me.app-descriptor      jad;
+    text/vnd.wap.wml                      wml;
+    text/x-component                      htc;
+
+    image/png                             png;
+    image/tiff                            tif tiff;
+    image/vnd.wap.wbmp                    wbmp;
+    image/x-icon                          ico;
+    image/x-jng                           jng;
+    image/x-ms-bmp                        bmp;
+    image/svg+xml                         svg svgz;
+    image/webp                            webp;
+
+    application/font-woff                 woff;
+    application/java-archive              jar war ear;
+    application/json                      json;
+    application/mac-binhex40              hqx;
+    application/msword                    doc;
+    application/pdf                       pdf;
+    application/postscript                ps eps ai;
+    application/rtf                       rtf;
+    application/vnd.apple.mpegurl         m3u8;
+    application/vnd.ms-excel              xls;
+    application/vnd.ms-fontobject         eot;
+    application/vnd.ms-powerpoint         ppt;
+    application/vnd.wap.wmlc              wmlc;
+    application/vnd.google-earth.kml+xml  kml;
+    application/vnd.google-earth.kmz      kmz;
+    application/x-7z-compressed           7z;
+    application/x-cocoa                   cco;
+    application/x-java-archive-diff       jardiff;
+    application/x-java-jnlp-file          jnlp;
+    application/x-makeself                run;
+    application/x-perl                    pl pm;
+    application/x-pilot                   prc pdb;
+    application/x-rar-compressed          rar;
+    application/x-redhat-package-manager  rpm;
+    application/x-sea                     sea;
+    application/x-shockwave-flash         swf;
+    application/x-stuffit                 sit;
+    application/x-tcl                     tcl tk;
+    application/x-x509-ca-cert            der pem crt;
+    application/x-xpinstall               xpi;
+    application/xhtml+xml                 xhtml;
+    application/xspf+xml                  xspf;
+    application/zip                       zip;
+
+    application/octet-stream              bin exe dll;
+    application/octet-stream              deb;
+    application/octet-stream              dmg;
+    application/octet-stream              iso img;
+    application/octet-stream              msi msp msm;
+
+    application/vnd.openxmlformats-officedocument.wordprocessingml.document    docx;
+    application/vnd.openxmlformats-officedocument.spreadsheetml.sheet          xlsx;
+    application/vnd.openxmlformats-officedocument.presentationml.presentation  pptx;
+
+    audio/midi                            mid midi kar;
+    audio/mpeg                            mp3;
+    audio/ogg                             ogg;
+    audio/x-m4a                           m4a;
+    audio/x-realaudio                     ra;
+
+    video/3gpp                            3gpp 3gp;
+    video/mp2t                            ts;
+    video/mp4                             mp4;
+    video/mpeg                            mpeg mpg;
+    video/quicktime                       mov;
+    video/webm                            webm;
+    video/x-flv                           flv;
+    video/x-m4v                           m4v;
+    video/x-mng                           mng;
+    video/x-ms-asf                        asx asf;
+    video/x-ms-wmv                        wmv;
+    video/x-msvideo                       avi;
+}

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -25,8 +25,8 @@ http {
         listen 80 default_server;
         listen 443 default_server ssl;
 
-        ssl_certificate /app/ssl/sprutio.crt;
-        ssl_certificate_key /app/ssl/sprutio.key;
+        ssl_certificate /etc/nginx/certs/sprutio.crt;
+        ssl_certificate_key /etc/nginx/certs/sprutio.key;
 
         # Allow file uploads
         client_max_body_size 2048M;

--- a/travis/docker-build.sh
+++ b/travis/docker-build.sh
@@ -19,9 +19,6 @@ docker build -t beget/sprutio-rpc -f rpc/Dockerfile rpc/
 # app image
 docker build -t beget/sprutio-app -f app/Dockerfile app/
 
-# nginx image
-docker build -t beget/sprutio-nginx -f Dockerfile.nginx ./
-
 # frontend
 docker build -t beget/sprutio-bower -f Dockerfile.bower ./
 docker run -v $PWD/app/public:/app -w /app beget/sprutio-bower bower install --allow-root

--- a/travis/docker-push.sh
+++ b/travis/docker-push.sh
@@ -20,7 +20,6 @@ docker login --email=$DOCKER_HUB_EMAIL --username=$DOCKER_HUB_USERNAME --passwor
 docker push beget/sprutio-cron
 docker push beget/sprutio-rpc
 docker push beget/sprutio-app
-docker push beget/sprutio-nginx
 docker push beget/sprutio-frontend
 
 # EOF


### PR DESCRIPTION
Так как beget/sprutio-nginx не содержит никаких изменений, но усложняет изменение конфига, при изменении конфига, сейчас надо перегенерировать контейнер, что не удобно.

Предлагаю вообще отказаться от него и вынести все конфиги на отдельный волум. Так можно легко изменять любые опции не изменяя контейнер.

TODO:
- так как сейчас используется устаревший docker-compose не позволяющий делать явные зависимости, то после первого создания проекта, контейнер nginx надо перезапустить (так как он стартует ещё без сертификатов и крашится)
- для того что бы данные изменения стали работоспособны надо обновить beget/sprutio-app (так как он содержит скрипт генерации ключей, который изменён)
